### PR TITLE
Fix/scrum 108 product detail modal mobile size initial count

### DIFF
--- a/src/pages/common/Modal.js
+++ b/src/pages/common/Modal.js
@@ -110,16 +110,16 @@ const Modal = () => {
                     )}
                 </div>
                 <div className={styles.modalFooter}>
-                    {type === 'productDetail' && isMobile && (
-                        <BottomPlaceOrder
-                            makeReservation={props.makeReservation}
-                            productDetail={props.productDetail}
-                            initialCount={props.initialCount}
-                            handleIncrease={props.handleIncrease}
-                            handleDecrease={props.handleDecrease}
-                            remainProduct={props.productDetail?.storeInfo?.remainProduct || 0}
-                        />
-                    )}
+                    {/*{type === 'productDetail' && isMobile && (*/}
+                    {/*    <BottomPlaceOrder*/}
+                    {/*        makeReservation={props.makeReservation}*/}
+                    {/*        productDetail={props.productDetail}*/}
+                    {/*        initialCount={props.initialCount}*/}
+                    {/*        handleIncrease={props.handleIncrease}*/}
+                    {/*        handleDecrease={props.handleDecrease}*/}
+                    {/*        remainProduct={props.productDetail?.storeInfo?.remainProduct || 0}*/}
+                    {/*    />*/}
+                    {/*)}*/}
                 </div>
             </div>
         </div>,

--- a/src/pages/product/BottomPlaceOrder.module.scss
+++ b/src/pages/product/BottomPlaceOrder.module.scss
@@ -39,37 +39,47 @@
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    
+
     &.reservation {
-      background-color: #d3d3d3; 
-      color: #000; 
+      background-color: #d3d3d3;
+      color: #000;
     }
   }
 }
 
 @media (max-width: 400px) {
-  .bottomPlaceOrder{
 
-    .productAmtAdjustBtn{
+  .bottomPlaceOrder {
+    //outline: 2px solid blue;
+    position: fixed;
+    bottom: 17px;
+    display: flex;
+    justify-content: space-between;
+    width: 90%;
+    left: 21px;
+    background: white;
+    padding: 4px 0;
+
+    .productAmtAdjustBtn {
       width: 35%;
 
-      .adjustBtn{
+      .adjustBtn {
         width: 35px;
         height: 35px;
       }
 
-      .initialCnt{
+      .initialCnt {
         font-size: 22px;
       }
     }
 
-    .placeOrderBtn{
+    .placeOrderBtn {
       width: 65%;
       font-size: 22px;
       padding: 11px;
 
       &.reservation {
-        background-color: #d3d3d3; 
+        background-color: #d3d3d3;
         color: #000;
       }
     }

--- a/src/pages/product/ProductDetailModal.js
+++ b/src/pages/product/ProductDetailModal.js
@@ -66,7 +66,7 @@ const ProductDetailModal = ({ productDetail, onClose }) => {
             <section className={styles.infoBox}>
                 <StoreInfo productDetail={productInfo} />
                 <ProductDetail productDetail={productInfo} />
-                {!isMobile && (
+                {isMobile? (
                     <BottomPlaceOrder
                         makeReservation={makeReservation}
                         productDetail={productInfo}
@@ -76,7 +76,15 @@ const ProductDetailModal = ({ productDetail, onClose }) => {
                         remainProduct={productCnt}
                         closeModal={closeModal}
                     />
-                )}
+                ) : <div className={styles.modalFooter}><BottomPlaceOrder
+                    makeReservation={makeReservation}
+                    productDetail={productInfo}
+                    initialCount={initialCount}
+                    handleIncrease={handleIncrease}
+                    handleDecrease={handleDecrease}
+                    remainProduct={productCnt}
+                    closeModal={closeModal}
+                    /></div>}
             </section>
             {!isMobile && (
                 <PaymentBox

--- a/src/pages/product/ProductDetailModal.js
+++ b/src/pages/product/ProductDetailModal.js
@@ -1,13 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import { useModal } from '../common/ModalProvider';
+import React, {useState, useEffect} from 'react';
+import {useModal} from '../common/ModalProvider';
 import styles from './ProductDetailModal.module.scss';
 import StoreInfo from './StoreInfo';
 import ProductDetail from './ProductDetail';
 import PaymentBox from './PaymentBox';
 import BottomPlaceOrder from './BottomPlaceOrder';
 
-const ProductDetailModal = ({ productDetail, onClose }) => {
-    const { closeModal } = useModal();
+const ProductDetailModal = ({productDetail, onClose}) => {
+    const {closeModal} = useModal();
 
     const [initialCount, setInitialCount] = useState(1);
     const [isMobile, setIsMobile] = useState(window.innerWidth <= 400);
@@ -47,7 +47,7 @@ const ProductDetailModal = ({ productDetail, onClose }) => {
 
     if (!productDetail) return null;
 
-    const { storeName, storeImg, address, openAt, closedAt, price, storeContact, productCnt } = productDetail;
+    const {storeName, storeImg, address, openAt, closedAt, price, storeContact, productCnt} = productDetail;
 
     const productInfo = {
         storeInfo: {
@@ -64,19 +64,9 @@ const ProductDetailModal = ({ productDetail, onClose }) => {
     return (
         <section className={styles.productDetailModal}>
             <section className={styles.infoBox}>
-                <StoreInfo productDetail={productInfo} />
-                <ProductDetail productDetail={productInfo} />
-                {isMobile? (
-                    <BottomPlaceOrder
-                        makeReservation={makeReservation}
-                        productDetail={productInfo}
-                        initialCount={initialCount}
-                        handleIncrease={handleIncrease}
-                        handleDecrease={handleDecrease}
-                        remainProduct={productCnt}
-                        closeModal={closeModal}
-                    />
-                ) : <div className={styles.modalFooter}><BottomPlaceOrder
+                <StoreInfo productDetail={productInfo}/>
+                <ProductDetail productDetail={productInfo}/>
+                <BottomPlaceOrder
                     makeReservation={makeReservation}
                     productDetail={productInfo}
                     initialCount={initialCount}
@@ -84,7 +74,7 @@ const ProductDetailModal = ({ productDetail, onClose }) => {
                     handleDecrease={handleDecrease}
                     remainProduct={productCnt}
                     closeModal={closeModal}
-                    /></div>}
+                />
             </section>
             {!isMobile && (
                 <PaymentBox

--- a/src/pages/product/ProductDetailModal.module.scss
+++ b/src/pages/product/ProductDetailModal.module.scss
@@ -198,6 +198,8 @@
   .productDetailModal{
     .infoBox{
         width: 100%;
+      //outline: 2px solid red;
+      margin-bottom: 35px;
     }
   }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
productDetailModal 에서 moblie size일 경우 initialCount가 전달이 안되는 문제 해결
<!---- Resolves: #(Isuue Number) -->

## PR 유형
<!-- # (어떤 변경 사항이 있나요?) -->

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 작업사항
- css로 처리

## 변경로직
- 기존에는 모바일 사이즈일 경우 '구매하기' 버튼을 모달 하단에 고정하고자 Modal.js 즉 상위 컴포넌트에서 modalFooter에 조건부 랜더링함.
- props가 정상적으로 전달되지 않아 문제가 발생했음

- 여러 방법을 시도해봤지만, 리액트에 아직 익숙하지 않아 웹, 모바일 똑같이 랜더링 하되 모바일 사이즈에만 scss를 다르게 적용하여 하단에 고정함
<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
